### PR TITLE
New module to add per Task Department

### DIFF
--- a/project_task_department/LICENSE
+++ b/project_task_department/LICENSE
@@ -1,0 +1,18 @@
+OpenERP, Open Source Management Solution
+
+Original author: Joël Grand-Guillaume
+Copyright © 2011 Camptocamp SA (http://www.camptocamp.com)
+Copyright © 2013 Daniel Reis (SECURITAS)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public Lice
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/project_task_department/__init__.py
+++ b/project_task_department/__init__.py
@@ -1,0 +1,1 @@
+from . import project_task

--- a/project_task_department/__openerp__.py
+++ b/project_task_department/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Project Task specific Department",
+    "version": "1.0",
+    "author": "Daniel Reis",
+    "license": "AGPL-3",
+    "category": "Generic Modules/Projects & Services",
+    "description": """\
+Task store the Department they correspond to.
+By default this is the Project Department.
+This module also makes it manually editable.
+""",
+    "website": "https://github.com/OCA/project-service",
+    "depends": [
+        "project_department",
+    ],
+    "data": ["project_view.xml"],
+    "installable": True,
+}

--- a/project_task_department/__openerp__.py
+++ b/project_task_department/__openerp__.py
@@ -6,9 +6,12 @@
     "license": "AGPL-3",
     "category": "Generic Modules/Projects & Services",
     "description": """\
-Task store the Department they correspond to.
-By default this is the Project Department.
-This module also makes it manually editable.
+Enables Tasks to store the Department they correspond to.
+By default this will be the Project Department, but it is editable.
+
+(Note that the ``project_department`` also adds a Department field on
+Tasks, but with the sole purpose of making the Project Department
+available on them.)
 """,
     "website": "https://github.com/OCA/project-service",
     "depends": [

--- a/project_task_department/project_task.py
+++ b/project_task_department/project_task.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Daniel Reis
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+
+
+class Task(models.Model):
+    _inherit = 'project.task'
+    department_id = fields.Many2one('hr.department', 'Department')
+
+    # Using old-style api for onchange
+    def onchange_project(self, cr, uid, ids, proj_id=False, context=None):
+        """ When Project is changed: copy it's Department to the issue. """
+        res = super(Task, self).onchange_project(
+            cr, uid, ids, proj_id, context=context)
+        res.setdefault('value', {})
+
+        if proj_id:
+            proj = self.pool.get('project.project').browse(
+                cr, uid, proj_id, context)
+            dept = getattr(proj, 'department_id', None)
+            if dept:
+                res['value'].update({'department_id': dept.id})
+            else:
+                res['value'].update({'department_id': None})
+
+        return res

--- a/project_task_department/project_view.xml
+++ b/project_task_department/project_view.xml
@@ -1,0 +1,41 @@
+<openerp>
+    <data>
+
+        <record id="view_task_search_form" model="ir.ui.view">
+            <field name="name">project.task.search.form</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_search_form"/>
+            <field name="arch" type="xml">
+              <field name="user_id" position="after">
+                <field name="department_id"/>
+              </field>
+              <filter name="User" position="after">
+                <filter string="Department" name="group_task_department_id" context="{'group_by':'department_id'}"/>
+              </filter>
+            </field>
+        </record>
+
+        <record id="view_task_form2" model="ir.ui.view">
+            <field name="name">project.task.department.form</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_form2"/>
+            <field name="arch" type="xml">
+                <field name="categ_ids" position="after">
+                  <field name="department_id" />
+                </field>
+            </field>
+        </record>
+
+        <record id="view_task_tree2" model="ir.ui.view">
+            <field name="name">project.task.department.tree</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="project.view_task_tree2"/>
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                  <field name="department_id"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
The `project_department` module makes the Project Department available in Tasks.
This module adds an editable field to Tasks, that may not correspond to the Project's Department.
