### PR TITLE
crm_departement : a section id change

### DIFF
--- a/crm_department/__init__.py
+++ b/crm_department/__init__.py
@@ -20,5 +20,3 @@
 #
 ##############################################################################
 import crm
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/crm_department/__openerp__.py
+++ b/crm_department/__openerp__.py
@@ -38,5 +38,3 @@ as well as the related filter and button in the search form.
     'auto_install': False,
     'application': True,
 }
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/crm_department/crm.py
+++ b/crm_department/crm.py
@@ -22,6 +22,7 @@
 ##############################################################################
 from openerp.osv import orm, fields
 
+
 class CrmSalesTeam(orm.Model):
     _inherit = "crm.case.section"
     _columns = {
@@ -31,11 +32,12 @@ class CrmSalesTeam(orm.Model):
     def _get_department(self, cr, uid, ids, context=None):
         employee_obj = self.pool['hr.employee']
         department_id = False
-        employee_ids = employee_obj.search(cr, uid, [('user_id','=', uid)])
+        employee_ids = employee_obj.search(cr, uid, [('user_id', '=', uid)])
         if employee_ids:
-            department_id = employee_obj.browse(cr, uid, 
-                                                employee_ids[0], 
-                                                context=context).department_id.id
+            department_id = employee_obj.browse(cr, uid,
+                                                employee_ids[0],
+                                                context=context
+                                                ).department_id.id
         return department_id
 
     _defaults = {
@@ -46,18 +48,21 @@ class CrmSalesTeam(orm.Model):
 class CrmLead(orm.Model):
     _inherit = "crm.lead"
 
-    def onchange_section_id(self, cr, uid, ids, section_id=False, context=None):
-        """ Updates res dictionary with the department corresponding to the section"""
+    def onchange_section_id(self, cr, uid,
+                            ids, section_id=False, context=None):
+        """ Updates res dictionary with the department
+        corresponding to the section"""
         res = {}
         if section_id:
-            section = self.pool.get('crm.case.section').browse(cr, uid, section_id, context=context)
+            section = self.pool.get('crm.case.section').browse(cr, uid,
+                                                               section_id,
+                                                               context=context)
             if section.department_id.id:
                 res.update({'department_id': section.department_id.id})
             if section.user_id.id:
-                res.update({'user_id':section.user_id.id})
-        return {'value':res}
-    
+                res.update({'user_id': section.user_id.id})
+        return {'value': res}
+
     _columns = {
         'department_id': fields.many2one('hr.department', 'Department'),
         }
-

--- a/crm_department/crm.py
+++ b/crm_department/crm.py
@@ -46,22 +46,6 @@ class CrmSalesTeam(orm.Model):
 class CrmLead(orm.Model):
     _inherit = "crm.lead"
 
-    def on_change_user(self, cr, uid, ids, user_id, context=None):
-        """ Updates res dictionary with the department 
-        corresponding to the section """
-        employee_obj = self.pool['hr.employee']
-        res = {}        
-        res['department_id'] = False
-        if user_id:
-            employee_ids = employee_obj.search(cr, uid, 
-                                               [('user_id','=',user_id)],
-                                                context=context)
-            for employee in employee_obj.browse(cr, uid, 
-                                               employee_ids, context=context):
-                if employee.department_id.id:
-                    res['department_id'] = employee.department_id.id
-        return {'value': res}
-    
     def onchange_section_id(self, cr, uid, ids, section_id=False, context=None):
         """ Updates res dictionary with the department corresponding to the section"""
         res = {}
@@ -69,6 +53,8 @@ class CrmLead(orm.Model):
             section = self.pool.get('crm.case.section').browse(cr, uid, section_id, context=context)
             if section.department_id.id:
                 res.update({'department_id': section.department_id.id})
+            if section.user_id.id:
+                res.update({'user_id':section.user_id.id})
         return {'value':res}
     
     _columns = {

--- a/crm_department/crm.py
+++ b/crm_department/crm.py
@@ -62,9 +62,16 @@ class CrmLead(orm.Model):
                     res['department_id'] = employee.department_id.id
         return {'value': res}
     
+    def onchange_section_id(self, cr, uid, ids, section_id=False, context=None):
+        """ Updates res dictionary with the department corresponding to the section"""
+        res = {}
+        if section_id:
+            section = self.pool.get('crm.case.section').browse(cr, uid, section_id, context=context)
+            if section.department_id.id:
+                res.update({'department_id': section.department_id.id})
+        return {'value':res}
+    
     _columns = {
         'department_id': fields.many2one('hr.department', 'Department'),
         }
 
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/crm_department/crm_view.xml
+++ b/crm_department/crm_view.xml
@@ -76,6 +76,9 @@
         <xpath expr="/form/sheet/group/group[3]/div" position="after">
           <field name="department_id" widget="selection"/>
         </xpath>
+        <xpath expr="//field[@name='user_id']" position="attributes">
+          <attribute name="on_change">onchange_user_id(user_id)</attribute>
+        </xpath>
       </field>
     </record>
 

--- a/crm_department/crm_view.xml
+++ b/crm_department/crm_view.xml
@@ -76,9 +76,6 @@
         <xpath expr="/form/sheet/group/group[3]/div" position="after">
           <field name="department_id" widget="selection"/>
         </xpath>
-        <xpath expr="//field[@name='user_id']" position="attributes">
-          <attribute name="on_change">onchange_user_id(user_id)</attribute>
-        </xpath>
       </field>
     </record>
 


### PR DESCRIPTION
- on_change_section python code ported from 6.1 + add the saleman in return value, to set the salesman corresponding to the salesteam reponsible.
- remove user_id python code, as it's not call from XML, and selecting a departement base on user_id is not usefull because a user can be on multiple department.
- pep 8 cleaning of the module
