### PR TITLE
[ADD][7.0] new module hours_block_department

### DIFF
--- a/hours_block_department/__init__.py
+++ b/hours_block_department/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import hours_block

--- a/hours_block_department/__openerp__.py
+++ b/hours_block_department/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# This file is part of hours_block_department,
+# an Odoo module.
+#
+# Authors: ACSONE SA/NV (<http://acsone.eu>)
+#
+# hours_block_department is free software:
+# you can redistribute it and/or modify it under the terms of the GNU
+# Affero General Public License as published by the Free Software
+# Foundation,either version 3 of the License, or (at your option) any
+# later version.
+#
+# hours_block_department is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with hours_block_department.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    "name": "Hours Blocks Department Categorization",
+    "version": "1.0",
+    "category": "Generic Modules/Projects & Services",
+    "author": "ACSONE SA/NV,Odoo Community Association (OCA)",
+    "website": "http://www.acsone.eu",
+    "description": """
+Hours Blocks Department Categorization
+======================================
+
+Replicate Department from invoice to Hours Blocks.
+Add it to corresponding tree, search and form views.
+
+This module is a part (OCA/department side) of the fix related to
+https://github.com/OCA/project-service/issues/33
+""",
+    "depends": [
+        "invoice_department",
+        "analytic_hours_block",     # OCA/project-service/analytic_hours_block
+    ],
+    "data": [
+        "hours_block_view.xml",
+    ],
+    "license": "AGPL-3",
+    "installable": True,
+    "application": False,
+    "active": True,
+}

--- a/hours_block_department/hours_block.py
+++ b/hours_block_department/hours_block.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# This file is part of hours_block_department,
+# an Odoo module.
+#
+# Authors: ACSONE SA/NV (<http://acsone.eu>)
+#
+# hours_block_department is free software:
+# you can redistribute it and/or modify it under the terms of the GNU
+# Affero General Public License as published by the Free Software
+# Foundation,either version 3 of the License, or (at your option) any
+# later version.
+#
+# hours_block_department is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with hours_block_department.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.osv import orm, fields
+
+
+class AccountHoursBlock(orm.Model):
+
+    _inherit = "account.hours.block"
+
+    def _get_hours_blocks_from_invoices(self, cr, uid, ids, context=None):
+        # self is an instance of account.invoice here
+        res = self.pool.get('account.hours.block').search(
+            cr, uid, [('invoice_id', 'in', ids)], context=context)
+        return res
+
+    _columns = {
+        'department_id': fields.related(
+            'invoice_id', 'department_id',
+            type='many2one', relation='hr.department',
+            string='Department',
+            store={
+                'account.hours.block': (
+                    lambda self, cr, uid, ids, c=None: ids,
+                    ['invoice_id'], 10),
+                'account.invoice': (
+                    _get_hours_blocks_from_invoices,
+                    ['department_id'], 10),
+            },
+            readonly=True),
+    }

--- a/hours_block_department/hours_block_view.xml
+++ b/hours_block_department/hours_block_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="view_account_invoice_filter" model="ir.ui.view">
+            <field name="name">account.hours.block.select (analytic_hours_block_department)</field>
+            <field name="model">account.hours.block</field>
+            <field name="inherit_id" ref="analytic_hours_block.view_account_invoice_filter"/>
+            <field name="arch" type="xml">
+                <data>
+                    <xpath expr="//field[@name='partner_id']" position="after">
+                        <field name="department_id" string="Department"/>
+                    </xpath>
+                    <xpath expr="//filter[@string='Responsible']" position="after">
+                        <filter string="Department" name="group_by_dept" icon="terp-personal" domain="[]"  context="{'group_by': 'department_id'}"/>
+                    </xpath>
+                </data>
+            </field>
+        </record>
+
+        <record id="hours_block_invoice_form" model="ir.ui.view">
+            <field name="name">account.hours.block.form (analytic_hours_block_department)</field>
+            <field name="model">account.hours.block</field>
+            <field name="inherit_id" ref="analytic_hours_block.hours_block_invoice_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='company_id']" position="after">
+                    <field name="department_id" string="Department"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="invoice_tree_hour_block" model="ir.ui.view">
+            <field name="name">account.hours.block.tree (analytic_hours_block_department)</field>
+            <field name="model">account.hours.block</field>
+            <field name="inherit_id" ref="analytic_hours_block.invoice_tree_hour_block"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='company_id']" position="after">
+                    <field name="department_id" string="Department"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="analytic_hours_block.action_all_block_hour" model="ir.actions.act_window">
+            <field name="context">{'search_default_running': 1, 'search_default_group_by_dept': 1}</field>
+        </record>
+
+    </data>
+</openerp>

--- a/hours_block_department/i18n/hours_block_department.pot
+++ b/hours_block_department/i18n/hours_block_department.pot
@@ -1,0 +1,28 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* hours_block_department
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-06-02 10:44+0000\n"
+"PO-Revision-Date: 2015-06-02 10:44+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: hours_block_department
+#: view:account.hours.block:0
+#: field:account.hours.block,department_id:0
+msgid "Department"
+msgstr ""
+
+#. module: hours_block_department
+#: model:ir.model,name:hours_block_department.model_account_hours_block
+msgid "Email Thread"
+msgstr ""
+

--- a/hours_block_department/tests/__init__.py
+++ b/hours_block_department/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+from . import test_hours_blocks_department
+
+checks = [
+    test_hours_blocks_department,
+]

--- a/hours_block_department/tests/test_hours_blocks_department.py
+++ b/hours_block_department/tests/test_hours_blocks_department.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# This file is part of hours_block_department,
+# an Odoo module.
+#
+# Authors: ACSONE SA/NV (<http://acsone.eu>)
+#
+# hours_block_department is free software:
+# you can redistribute it and/or modify it under the terms of the GNU
+# Affero General Public License as published by the Free Software
+# Foundation,either version 3 of the License, or (at your option) any
+# later version.
+#
+# hours_block_department is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+# PURPOSE. See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with hours_block_department.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import openerp.tests.common as common
+
+
+class TestReplicateInvoiceDepartmentOnHoursBlock(common.TransactionCase):
+
+    def setUp(self):
+        super(TestReplicateInvoiceDepartmentOnHoursBlock, self).setUp()
+        self.ai_model = self.registry('account.invoice')
+        self.hb_model = self.registry('account.hours.block')
+
+        self.ai1 = self.ref('analytic_hours_block.demo_invoice_4_hb')
+        self.hb1 = self.ref('analytic_hours_block.demo_hb')
+        self.hd1 = self.ref('hr.dep_ps')
+
+        self.context = {}
+
+    def test_change_period(self):
+        cr, uid, context = self.cr, self.uid, self.context
+        ai_model, hb_model = self.ai_model, self.hb_model
+
+        ai = ai_model.browse(cr, uid, self.ai1, context=context)
+        hb = hb_model.browse(cr, uid, self.hb1, context=context)
+
+        # 1. Verify demo data
+        self.assertFalse(ai.department_id.id,
+                         "Wrong demo data: "
+                         "test_invoice_1.department_id should be False")
+        self.assertFalse(hb.department_id.id,
+                         "Wrong demo data: "
+                         "demo_hb_4_test_invoice_1.department_id "
+                         "should be False")
+
+        # 2. Change Invoice Department
+        vals = {'department_id': self.hd1}
+        ai.write(vals)
+        hb = hb_model.browse(cr, uid, self.hb1, context=context)
+        self.assertEqual(
+            hb.department_id.id, self.hd1,
+            "Replicate Department on Invoice fails: "
+            "demo_hb_4_test_invoice_1.department_id "
+            "should be %s" % self.hd1)
+
+        # 3 Rollback the change
+        vals = {'department_id': False}
+        ai.write(vals)
+        hb = hb_model.browse(cr, uid, self.hb1, context=context)
+        self.assertFalse(
+            hb.department_id.id,
+            "Replicate Department on Invoice fails: "
+            "demo_hb_4_test_invoice_1.department_id "
+            "should be False")
+        pass


### PR DESCRIPTION
The module adds a `department_id` field on `account.hours.block` model that is a replication of `invoice.department_id` defined in the `invoice_department` module. It is automatically installed as soon as both `invoice_department` and `analytic_hours_block` are installed.

This PR is a part of the fix related to https://github.com/OCA/project-service/issues/33.
