### PR TITLE
[FIX] Removing on_change_section_id from view

### DIFF
--- a/crm_department/crm_view.xml
+++ b/crm_department/crm_view.xml
@@ -70,9 +70,6 @@
       <field name="model">crm.lead</field>
       <field name="inherit_id" ref="crm.crm_case_form_view_oppor" />
       <field name="arch" type="xml">
-        <xpath expr="/form/sheet/group/group[3]/div/field[@name='section_id']" position="attributes">
-          <attribute name="on_change">onchange_section_id(section_id)</attribute>
-        </xpath>
         <xpath expr="/form/sheet/group/group[3]/div" position="after">
           <field name="department_id" widget="selection"/>
         </xpath>


### PR DESCRIPTION
On https://github.com/OCA/department/commit/dbef5a42ee538ffcdf8ab880144942e4f5dd4ac2 

@jbeficent remove onchange_section_id Is this right?

Some use cases:

1 - User from department A, create a new LEAD, on_change_user get the default hr.department from employee.department_id.id;
2 - User from department A, create a new LEAD, on_change_user get the default hr.department from employee.department_id.id, he changes section_id to SECTION B, with default department B. 

The preference is always from employee.department_id.id? It would not be correct to seek: the sales team's department and if it is not available look for the user's department?

Best Regards
